### PR TITLE
Make it go

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -81,6 +81,14 @@ class Discord extends AbstractProvider
     /**
      * {@inheritdoc}
      */
+    protected function getAuthorizationHeaders($token = null)
+    {
+        return ['Authorization' => 'Bearer '.$token];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function checkResponse(ResponseInterface $response, $data)
     {
     }
@@ -90,5 +98,6 @@ class Discord extends AbstractProvider
      */
     protected function createResourceOwner(array $response, AccessToken $token)
     {
+        return $response;
     }
 }


### PR DESCRIPTION
- `getAuthorizationHeaders()` requires overloading because `AbstractProvider` does not provide a default value. Otherwise any requests post-authentication (through `getAuthenticatedRequest()`) wont work.
- `createResourceOwner()` should at least return the response array for `getResourceOwner()` to work decently. Though, in a perfect world where I wasn't lazy it would return something that implements `ResourceOwnerInterface`
