### PR TITLE
Update league/oauth2-client dependency to version 2.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "league/oauth2-client": "^1.3",
+        "league/oauth2-client": "^2.2.1",
         "illuminate/support": "^5.2"
     },
     "require-dev": {

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -124,7 +124,7 @@ class Discord extends AbstractProvider
             $method, $url, $token, $options
         );
 
-        return $this->getResponse($request);
+        return $this->getParsedResponse($request);
     }
 
     /**


### PR DESCRIPTION
Currently uses `league/oauth2-client` version 1.3 which in turn uses `ircmaxell/random-lib` version 1.1 which uses the mcrypt extension which is deprecated in PHP 7.1

Updating `league/oauth2-client` to version 2.2.1 solves this issue because it doesn't use `ircmaxell/random-lib` anymore (but a different package which doesn't use mcrypt).
