### PR TITLE
Upping the league requirement to the 2.x range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "league/oauth2-client": "^1.3",
+        "league/oauth2-client": "^2.1",
         "illuminate/support": "^5.2"
     },
     "require-dev": {


### PR DESCRIPTION
It looks like this library was written when the League client was in the `1.x` world so it requires a `1.x` version. The League client is now in `2.x` so this PR just updates that requirement so it can be installed with a more recent version.

I'm assuming here that there haven't been any major changes for providers between the versions but I haven't tried it out for myself.