### PR TITLE
Update BASE_URL to new domain

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -24,7 +24,7 @@ class Discord extends AbstractProvider
      *
      * @var string Base API url.
      */
-    const BASE_API_URL = 'https://discordapp.com/api';
+    const BASE_API_URL = 'https://discord.com/api';
 
     /**
      * An array of available OAuth scopes.


### PR DESCRIPTION
From Discord

> Last month, we excitedly announced our official move to discord.com. It was a long time in the making, and the work isn't done yet! For now, our API will continue to handle requests made to discordapp.com. On November 7, 2020 we will be dropping support for the discordapp.com domain in favor of discord.com. Please ensure that your libraries, bots, and applications are updated accordingly.

BASE_URL should needs be updated to the new domain to continue working